### PR TITLE
Add logTestPurpose to record test purpose in the test case output

### DIFF
--- a/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_helloworld/TC0001.java
+++ b/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_helloworld/TC0001.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, [name of copyright owner, Johannes Mulder (Fraunhofer IOSB)"]
+Copyright 2015, Johannes Mulder (Fraunhofer IOSB)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -51,7 +51,11 @@ public class TC0001 extends AbstractTestCase {
      * @param args the parameter line arguments
      */
     public static void main(final String[] args) {
+        new TC0001().execute(helloWorldTcParam, helloWorldBaseModel, logger);
+    }
 
+    @Override
+    protected void logTestPurpose() {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("\n");
         stringBuilder.append("---------------------------------------------------------------------\n");
@@ -65,8 +69,6 @@ public class TC0001 extends AbstractTestCase {
         final String testPurpose = stringBuilder.toString();
 
         logger.info(testPurpose);
-
-        new TC0001().execute(helloWorldTcParam, helloWorldBaseModel, logger);
     }
 
 

--- a/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_helloworld/TC0002.java
+++ b/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_helloworld/TC0002.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, [name of copyright owner, Johannes Mulder (Fraunhofer IOSB)"]
+Copyright 2015, Johannes Mulder (Fraunhofer IOSB)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -61,7 +61,11 @@ public class TC0002 extends AbstractTestCase {
      * @param args the parameter line arguments
      */
     public static void main(final String[] args) {
+        new TC0002().execute(helloWorldTcParam, helloWorldBaseModel, logger);
+    }
 
+    @Override
+    protected void logTestPurpose() {
         final StringBuilder stringBuilder = new StringBuilder();
         stringBuilder.append("\n");
         stringBuilder.append("---------------------------------------------------------------------\n");
@@ -74,11 +78,9 @@ public class TC0002 extends AbstractTestCase {
         final String testPurpose = stringBuilder.toString();
 
         logger.info(testPurpose);
-
-        new TC0002().execute(helloWorldTcParam, helloWorldBaseModel, logger);
     }
 
-
+    
     @Override
     protected void preambleAction() throws TcInconclusive {
 

--- a/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_lib_helloworld/HelloWorldBaseModel.java
+++ b/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_lib_helloworld/HelloWorldBaseModel.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, [name of copyright owner, Johannes Mulder (Fraunhofer IOSB)"]
+Copyright 2015, Johannes Mulder (Fraunhofer IOSB)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_lib_helloworld/HelloWorldTcParam.java
+++ b/TS_HelloWorld/src/main/java/de/fraunhofer/iosb/tc_lib_helloworld/HelloWorldTcParam.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2015, [name of copyright owner, Johannes Mulder (Fraunhofer IOSB)"]
+Copyright 2015, Johannes Mulder (Fraunhofer IOSB)
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
A new function to log the test purpose has been added to
AbstractTestCase and is required for each test case derived from this
class.